### PR TITLE
Fix typo flag country code

### DIFF
--- a/src/bootstrap-select-country.js
+++ b/src/bootstrap-select-country.js
@@ -33,7 +33,7 @@ let countrypicker = function(opts) {
 				$.each(countries, function (index, country) {
 					options.push(`<option
 						data-tokens="${country.code}"
-						data-icon="inline-flag flag ${country.code}.toLowerCase()"
+						data-icon="inline-flag flag ${country.code.toLowerCase()}"
 						class="option-with-flag"
 						value="${country.code}">${country.name}</option>`);
 				});


### PR DESCRIPTION
Flags country codes were outputted as `"inline-flag flag 
 ##.toLowerCase()"` instead of the country code being made to be lowercase as was originally intended.

This fixes that.